### PR TITLE
Don't delete message until after converting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -91,12 +91,6 @@ class Zana(commands.Bot):
                         self.server_config.conf[str(ctx.guild.id)].get('convert'):
                     return
                 self.loop.create_task(self.convert_command.invoke(ctx))
-                try:
-                    await ctx.message.delete()
-                except Exception:
-                    #Funny thing is, error is an embed, if someone removes that perm,
-                    #the error doesn't go through as well
-                    await ctx.error("`Manage Messages` required to delete", delete_after=2)
             except Exception:
                 await self.report(ctx.message.content)
         else:

--- a/cogs/poe.py
+++ b/cogs/poe.py
@@ -631,6 +631,12 @@ class PathOfExile(Cog):
         embed.set_footer(text="Don't want your items converted? An admin can disable it using @Zana disable_conversion.")
         try:
             embed_msg = await ctx.send(embed=embed)
+            try:
+                await ctx.message.delete()
+            except Exception:
+                #Funny thing is, error is an embed, if someone removes that perm,
+                #the error doesn't go through as well
+                await ctx.error("`Manage Messages` required to delete", delete_after=2)
             env_emoji = '📩'
             try:
                 await embed_msg.add_reaction(env_emoji)
@@ -662,6 +668,11 @@ class PathOfExile(Cog):
                 await ctx.send(f"**{ctx.author.name}#{ctx.author.discriminator}**:\n", file=file)
             except Exception:
                 await ctx.error("`Attach Files` permission required", delete_after=2)
+            else:
+                try:
+                    await ctx.message.delete()
+                except Exception:
+                    await ctx.error("`Manage Messages` required to delete", delete_after=2)
 
     @commands.command()
     async def roll(self, ctx, *, item: str = None):


### PR DESCRIPTION
If an error occurs during conversion, we will leave the original message intact.

An example of something it fails to convert (and just deletes the message for):
```
Rarity: Rare
Torment Horn
Bone Helmet
--------
Armour: 203 (augmented)
Energy Shield: 49 (augmented)
--------
Requirements:
Level: 73
Str: 76
Dex: 92
Int: 151
--------
Sockets: B-G-B-B 
--------
Item Level: 75
--------
+36% to Lightning Golem Elemental Resistances (enchant)
--------
Minions deal 19% increased Damage (implicit)
--------
+6 to Armour
+11 to maximum Energy Shield
+98 to maximum Life
+23% to Lightning Resistance
+9% to Fire and Chaos Resistances (crafted)
```